### PR TITLE
fix: remove unnecessary min-h-screen from hero

### DIFF
--- a/src/app/(routes)/across-bridge/_components/hero-section.tsx
+++ b/src/app/(routes)/across-bridge/_components/hero-section.tsx
@@ -9,7 +9,7 @@ import bridgeHeroImage from "@/app/_assets/bridge-hero.png";
 
 export function HeroSection() {
   return (
-    <Hero className="md:-mb-[180px]">
+    <Hero>
       <div className="container mx-auto flex flex-col items-center gap-16 px-4 pb-16 pt-8 md:flex-row-reverse md:gap-8 md:pt-16">
         <div className="flex max-w-80 flex-1 sm:max-w-100 md:max-w-full">
           <Image src={bridgeHeroImage} alt="Across bridge ui" priority={true} />

--- a/src/app/(routes)/across-plus/_components/hero-section.tsx
+++ b/src/app/(routes)/across-plus/_components/hero-section.tsx
@@ -8,7 +8,7 @@ import { INTEGRATION_LINKS } from "@/app/_constants/links";
 
 export function HeroSection() {
   return (
-    <Hero className="md:-mb-[360px]">
+    <Hero>
       <div className="container mx-auto flex flex-col items-center gap-16 px-4 pb-16 pt-8 md:flex-row-reverse md:gap-8 md:pt-16">
         <div className="flex max-w-80 flex-1 sm:max-w-100 md:max-w-full">
           <Image src={plusHeroSrc} alt="Across plus graphic" priority={true} />

--- a/src/app/(routes)/across-settlement/_components/hero-section.tsx
+++ b/src/app/(routes)/across-settlement/_components/hero-section.tsx
@@ -8,7 +8,7 @@ import { Hero } from "@/app/_components/hero";
 
 export function HeroSection() {
   return (
-    <Hero className="md:-mb-[360px]">
+    <Hero>
       <div className="container mx-auto flex flex-col items-center gap-16 px-4 pb-16 pt-8 md:flex-row-reverse md:gap-8 md:pt-16">
         <div className="flex max-w-80 flex-1 sm:max-w-100 md:max-w-full">
           <Image

--- a/src/app/_components/hero.tsx
+++ b/src/app/_components/hero.tsx
@@ -1,11 +1,10 @@
 import { ComponentProps } from "react";
-import { twMerge } from "@/app/_lib/tw-merge";
 
 type HeroProps = ComponentProps<"section">;
 
 export function Hero({ className, children, ...props }: HeroProps) {
   return (
-    <section className={twMerge("min-h-screen", className)} {...props}>
+    <section className={className} {...props}>
       {children}
     </section>
   );


### PR DESCRIPTION
The class `min-h-screen` in the hero component was causing issues for some window sizes. 