### PR TITLE
feat(tracking): allow passthrough of link and track page urls

### DIFF
--- a/src/app/_amplitude/index.ts
+++ b/src/app/_amplitude/index.ts
@@ -220,6 +220,49 @@ export interface BridgeButtonClickedProperties {
     | "marketingHero";
 }
 
+export interface CtaButtonClickedProperties {
+  /**
+   * | Rule | Value |
+   * |---|---|
+   * | Enum Values | splashPage, bridgePage, poolPage, rewardsPage, transactionsPage, stakingPage, referralPage, airdropPage, 404Page, marketingHomePage, marketingBridgePage, marketingAcrossPlusPage, marketingSettlementPage, depositStatusPage |
+   */
+  page:
+    | "splashPage"
+    | "bridgePage"
+    | "poolPage"
+    | "rewardsPage"
+    | "transactionsPage"
+    | "stakingPage"
+    | "referralPage"
+    | "airdropPage"
+    | "404Page"
+    | "marketingHomePage"
+    | "marketingBridgePage"
+    | "marketingAcrossPlusPage"
+    | "marketingSettlementPage"
+    | "depositStatusPage";
+  /**
+   * | Rule | Value |
+   * |---|---|
+   * | Enum Values | navbar, mobileNavSidebar, addLiquidityForm, removeLiquidityForm, airdropSplashFlow, referralTable, rewardsTable, unstakeForm, myTransactionsTable, bridgeForm, claimReferralRewardsForm, stakeForm, depositConfirmation, marketingHero |
+   */
+  section:
+    | "navbar"
+    | "mobileNavSidebar"
+    | "addLiquidityForm"
+    | "removeLiquidityForm"
+    | "airdropSplashFlow"
+    | "referralTable"
+    | "rewardsTable"
+    | "unstakeForm"
+    | "myTransactionsTable"
+    | "bridgeForm"
+    | "claimReferralRewardsForm"
+    | "stakeForm"
+    | "depositConfirmation"
+    | "marketingHero";
+}
+
 export interface PageViewedProperties {
   /**
    * Hash to identify the UI version when event was triggered
@@ -259,6 +302,10 @@ export interface PageViewedProperties {
    * Referring url
    */
   referrer?: string;
+  /**
+   * The current URL of the website on which this event was generated
+   */
+  siteUrl?: string;
 }
 
 export class Identify implements BaseEvent {
@@ -277,6 +324,14 @@ export class BridgeButtonClicked implements BaseEvent {
   event_type = "BridgeButtonClicked";
 
   constructor(public event_properties: BridgeButtonClickedProperties) {
+    this.event_properties = event_properties;
+  }
+}
+
+export class CtaButtonClicked implements BaseEvent {
+  event_type = "CTAButtonClicked";
+
+  constructor(public event_properties: CtaButtonClickedProperties) {
     this.event_properties = event_properties;
   }
 }
@@ -438,6 +493,23 @@ export class Ampli {
     options?: EventOptions,
   ) {
     return this.track(new BridgeButtonClicked(properties), options);
+  }
+
+  /**
+   * CTAButtonClicked
+   *
+   * [View in Tracking Plan](https://data.amplitude.com/risklabs/Risk%20Labs/events/main/latest/CTAButtonClicked)
+   *
+   * When an Across Marketing CTA is clicked
+   *
+   * @param properties The event's properties (e.g. page)
+   * @param options Amplitude event options.
+   */
+  ctaButtonClicked(
+    properties: CtaButtonClickedProperties,
+    options?: EventOptions,
+  ) {
+    return this.track(new CtaButtonClicked(properties), options);
   }
 
   /**

--- a/src/app/_components/bridge-now-link.tsx
+++ b/src/app/_components/bridge-now-link.tsx
@@ -21,7 +21,17 @@ function _BridgeNowLink({ className, section, ...props }: Props) {
   const searchParams = useSearchParams();
 
   const refParams = searchParams.get("ref") || searchParams.get("referrer");
-  const bridgeNowLink = `${bridgeAppBaseUrl}/bridge${refParams ? `?ref=${refParams}` : ""}`;
+  const integratorParams = searchParams.get("integrator");
+
+  const params = new URLSearchParams();
+  if (refParams) {
+    params.set("ref", refParams);
+  }
+  if (integratorParams) {
+    params.set("integrator", integratorParams);
+  }
+
+  const bridgeNowLink = `${bridgeAppBaseUrl}/bridge?${params.toString()}`;
 
   const pathname = usePathname();
   const actionCallback = () => {

--- a/src/app/_components/footer.tsx
+++ b/src/app/_components/footer.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Link from "next/link";
 
 import {
   AcrossFullIcon,
@@ -17,6 +16,7 @@ import {
 import { IconBox } from "./icon-box";
 import { PRODUCT_LINKS, SOCIAL_LINKS, INFORMATION_LINKS } from "@/app/_constants";
 import { twMerge } from "@/app/_lib/tw-merge";
+import CustomLink from "./link";
 
 const products = [
   {
@@ -120,9 +120,9 @@ function FooterBox(props: {
                 <FooterBoxItem item={item} />
               </a>
             ) : (
-              <Link href={item.href}>
+              <CustomLink href={item.href} preserveQueryParams>
                 <FooterBoxItem item={item} />
-              </Link>
+              </CustomLink>
             )}
           </div>
         ))}

--- a/src/app/_components/header-nav/products-sub-nav.tsx
+++ b/src/app/_components/header-nav/products-sub-nav.tsx
@@ -1,10 +1,10 @@
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { twMerge } from "@/app/_lib/tw-merge";
 
 import { IconBox } from "../icon-box";
 
 import { NavItem } from "./types";
+import CustomLink from "../link";
 
 const classNameOverrides: Record<
   string,
@@ -36,7 +36,8 @@ export function ProductsSubNav(props: { navItems: NavItem[] }) {
       <div className="flex flex-row items-center justify-start gap-4 bg-grey-dark min-[500px]:justify-center">
         {props.navItems.map((item) => (
           <span key={item.href} className="group">
-            <Link
+            <CustomLink
+              preserveQueryParams
               key={item.href}
               href={item.href}
               className={twMerge(
@@ -69,7 +70,7 @@ export function ProductsSubNav(props: { navItems: NavItem[] }) {
               >
                 {item.label}
               </div>
-            </Link>
+            </CustomLink>
           </span>
         ))}
       </div>

--- a/src/app/_components/link.tsx
+++ b/src/app/_components/link.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link, { LinkProps } from "next/link";
-import React from "react";
+import { useSearchParams } from "next/navigation";
+import React, { Suspense } from "react";
 
 type CustomLinkProps = LinkProps & {
   preserveQueryParams?: boolean;
@@ -15,11 +16,17 @@ type CustomLinkProps = LinkProps & {
  * will be preserved when navigating to the new page. Providing new query params will effectively override this behavior.
  */
 function CustomLink({ href, preserveQueryParams, ...props }: CustomLinkProps) {
+  const params = useSearchParams();
   if (preserveQueryParams && !href.toString().includes("?")) {
-    const currentQueryParams = new URLSearchParams(window.location.search);
-    href = `${href.toString()}?${currentQueryParams.toString()}`;
+    href = `${href.toString()}?${params.toString()}`;
   }
   return <Link href={href} {...props} />;
 }
 
-export default CustomLink;
+export default function CustonLinkWithSuspense(props: CustomLinkProps) {
+  return (
+    <Suspense>
+      <CustomLink {...props} />
+    </Suspense>
+  );
+}

--- a/src/app/_components/link.tsx
+++ b/src/app/_components/link.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import Link, { LinkProps } from "next/link";
+import React from "react";
+
+type CustomLinkProps = LinkProps & {
+  preserveQueryParams?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+};
+
+/**
+ * A comparable component to Next.js's Link component that allows for custom behavior. Specifically, the add to
+ * using this component is the ability to preserve query params when navigating to a new page. If set, the query params
+ * will be preserved when navigating to the new page. Providing new query params will effectively override this behavior.
+ */
+function CustomLink({ href, preserveQueryParams, ...props }: CustomLinkProps) {
+  if (preserveQueryParams && !href.toString().includes("?")) {
+    const currentQueryParams = new URLSearchParams(window.location.search);
+    href = `${href.toString()}?${currentQueryParams.toString()}`;
+  }
+  return <Link href={href} {...props} />;
+}
+
+export default CustomLink;

--- a/src/app/_hooks/usePageTracking.ts
+++ b/src/app/_hooks/usePageTracking.ts
@@ -16,6 +16,7 @@ export function usePageTracking() {
     if (isAmpliInitialized && pathname) {
       const referrer = document.referrer;
       const origin = window.location.origin;
+      const siteUrl = window.location.href;
       ampli.pageViewed({
         gitCommitHash: GIT_COMMIT_HASH,
         page: pageLookup(pathname),
@@ -23,6 +24,7 @@ export function usePageTracking() {
         referrer,
         origin,
         isInitialPageView,
+        siteUrl,
       });
     }
     setIsInitialPageView(true);


### PR DESCRIPTION
We should be tracking site urls on each page view. Additionally - our internal page routing should pass params around if not already set.