### PR TITLE
fix/canonical links

### DIFF
--- a/src/app/(routes)/blog/[slug]/page.tsx
+++ b/src/app/(routes)/blog/[slug]/page.tsx
@@ -16,6 +16,7 @@ import ShareLink from "./_components/share-link";
 import ArticleSnippetCard from "../_components/article-snippet-card";
 import { Metadata } from "next";
 import { documentToPlainTextString } from "@contentful/rich-text-plain-text-renderer";
+import { SITE_BASE_URL } from "@/app/_constants/links";
 
 type SpecificBlogPageProps = { params: { slug: string } };
 
@@ -33,12 +34,10 @@ export async function generateMetadata({
 
   return {
     keywords: entry.fields.tag ?? [],
+    metadataBase: new URL(SITE_BASE_URL),
     publisher: "Across Protocol",
     alternates: {
-      canonical: "/",
-      languages: {
-        "en-US": "/en-US",
-      },
+      canonical: `/blog/${params.slug}`,
     },
     title,
     description,
@@ -50,6 +49,13 @@ export async function generateMetadata({
       site: "@AcrossProtocol",
       title,
       images: [imageUrl],
+    },
+    openGraph: {
+      siteName: "Across Protocol",
+      title,
+      description,
+      images: [imageUrl],
+      url: `/blog/${params.slug}`,
     },
   };
 }

--- a/src/app/_constants/links.ts
+++ b/src/app/_constants/links.ts
@@ -56,3 +56,5 @@ export const INTEGRATION_LINKS = {
   settlement:
     "https://docs.across.to/v/v3-developer-docs/concepts/intents-architecture-in-across",
 };
+
+export const SITE_BASE_URL = "https://across.to" as const;


### PR DESCRIPTION
## motivation

The canonical links generated for each blog entry page was only the base URL for the site.
Canonicla URLs for blog entries:
`https://across.to/` => `https://across.to/blog/${entry.slug}`