### PR TITLE
fix zora logo gradient

### DIFF
--- a/src/app/_components/icons/gradient/logos/zora.tsx
+++ b/src/app/_components/icons/gradient/logos/zora.tsx
@@ -58,14 +58,13 @@ export function ZoraIcon({ variant = "aqua", ...props }: LogoIconProps) {
       </defs>
       <g>
         <path
-          d="M100 50C100 22.3858 77.6142 0 50 0C22.3858 0 0 22.3858 0 50C0 77.6142 22.3858 100 50 100C77.6142 100 100 77.6142 100 50Z"
-          fill={`url(#${linearGradientBasedId})`}
-        />
-        <path
           stroke={baseColors[variant]}
-          fill="url(#radial_gradient)"
           strokeWidth="1"
           d="M50,0.5c27.3,0,49.5,22.2,49.5,49.5S77.3,99.5,50,99.5S0.5,77.3,0.5,50S22.7,0.5,50,0.5z"
+        />
+        <path
+          d="M100 50C100 22.3858 77.6142 0 50 0C22.3858 0 0 22.3858 0 50C0 77.6142 22.3858 100 50 100C77.6142 100 100 77.6142 100 50Z"
+          fill={`url(#${linearGradientBasedId})`}
         />
       </g>
     </svg>

--- a/src/app/_components/icons/gradient/logos/zora.tsx
+++ b/src/app/_components/icons/gradient/logos/zora.tsx
@@ -61,9 +61,6 @@ export function ZoraIcon({ variant = "aqua", ...props }: LogoIconProps) {
           stroke={baseColors[variant]}
           strokeWidth="1"
           d="M50,0.5c27.3,0,49.5,22.2,49.5,49.5S77.3,99.5,50,99.5S0.5,77.3,0.5,50S22.7,0.5,50,0.5z"
-        />
-        <path
-          d="M100 50C100 22.3858 77.6142 0 50 0C22.3858 0 0 22.3858 0 50C0 77.6142 22.3858 100 50 100C77.6142 100 100 77.6142 100 50Z"
           fill={`url(#${linearGradientBasedId})`}
         />
       </g>


### PR DESCRIPTION
I noticed this bug on webkit browsers. 
These are 2 paths defined for this svg, the outline and the inner radial gradient.
They are defined in the wrong order.  For some reason chrome handles this gracefully.
These can be merged into one path with a border(stroke) and fill properties.
 
![Screenshot 2025-01-02 at 16 00 35](https://github.com/user-attachments/assets/64f80459-d654-41e8-8a30-7c7db55bf853)
